### PR TITLE
Vorschlag: Text-Strings nur als Template-Literals variablen

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -45,6 +45,7 @@ const baseConfig = {
     "react-refresh/only-export-components": ["warn",
       { allowConstantExport: true },
     ],
+    "prefer-template": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": "warn",
     "jsx-a11y/anchor-is-valid": "off", // TODO discuss accesibility issue or convert links to buttons
@@ -56,6 +57,7 @@ const baseConfig = {
     "jsx-a11y/no-autofocus": "warn",
     "jsx-a11y/no-noninteractive-element-interactions": "warn",
     "jsx-a11y/no-static-element-interactions": "off", // TODO
+    "react/jsx-no-literals": "warn",
     "react/jsx-no-target-blank": "warn",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",

--- a/src/bplan-auskunft/InfoBoxText.jsx
+++ b/src/bplan-auskunft/InfoBoxText.jsx
@@ -4,28 +4,12 @@ export const InfoBoxText = ({ setAppMenuVisible }) => {
   return (
     <>
       <ul>
-        <li>
-          <b>einen B-Plan laden:</b> Doppelklick auf Plan in Hintergrundkarte
-        </li>
-        <li>
-          <b>alle B-Pl&auml;ne im Kartenausschnitt laden:</b>{" "}
-          <Icon name="search" />
-        </li>
-        <li>
-          <b>bekannten B-Plan laden:</b> Nummer als Suchbegriff eingeben,
-          Auswahl aus Vorschlagsliste
-        </li>
-        <li>
-          <b>Suche nach B-Pl&auml;nen:</b> Adresse oder POI als Suchbegriff
-          eingeben, Auswahl aus Vorschlagsliste
-        </li>
+        <li><b>einen B-Plan laden:</b> Doppelklick auf Plan in Hintergrundkarte</li>
+        <li><b>{`alle B-Pläne im Kartenausschnitt laden: `}</b><Icon name="search" /></li>
+        <li><b>bekannten B-Plan laden:</b> Nummer als Suchbegriff eingeben, Auswahl aus Vorschlagsliste </li>
+        <li><b>{`Suche nach B-Plänen:`}</b> Adresse oder POI als Suchbegriff eingeben, Auswahl aus Vorschlagsliste</li>
       </ul>
-      <a
-        onClick={() => {
-          setAppMenuVisible(true);
-        }}
-        style={{ cursor: "pointer", color: "#0078A8" }}
-      >
+      <a onClick={() => {setAppMenuVisible(true);}} style={{ cursor: "pointer", color: "#0078A8" }}>
         Kompaktanleitung
       </a>
     </>

--- a/src/bplan-auskunft/InfoBoxText.tsx
+++ b/src/bplan-auskunft/InfoBoxText.tsx
@@ -8,29 +8,13 @@ export const InfoBoxText = ({ setAppMenuVisible }: InfoBoxTextProps) => {
   return (
     <>
       <ul>
-        <li>
-          <b>einen B-Plan laden:</b> Doppelklick auf Plan in Hintergrundkarte
-        </li>
-        <li>
-          <b>alle B-Pl&auml;ne im Kartenausschnitt laden:</b>{" "}
-          <Icon name="search" />
-        </li>
-        <li>
-          <b>bekannten B-Plan laden:</b> Nummer als Suchbegriff eingeben,
-          Auswahl aus Vorschlagsliste
-        </li>
-        <li>
-          <b>Suche nach B-Pl&auml;nen:</b> Adresse oder POI als Suchbegriff
-          eingeben, Auswahl aus Vorschlagsliste
-        </li>
+        <li><b>{`einen B-Plan laden:`}</b>{` Doppelklick auf Plan in Hintergrundkarte `}</li>
+        <li><b>{`alle B-Pläe im Kartenausschnitt laden: `}</b><Icon name="search" /></li>
+        <li><b>{`bekannten B-Plan laden:`}</b>{` Nummer als Suchbegriff eingeben, Auswahl aus Vorschlagsliste`}</li>
+        <li><b>{`Suche nach B-Plänen:`}</b>{` Adresse oder POI als Suchbegriff eingeben, Auswahl aus Vorschlagsliste`}</li>
       </ul>
-      <a
-        onClick={() => {
-          setAppMenuVisible(true);
-        }}
-        style={{ cursor: "pointer", color: "#0078A8" }}
-      >
-        Kompaktanleitung
+      <a onClick={() => { setAppMenuVisible(true); }} style={{ cursor: "pointer", color: "#0078A8" }}>
+        {`Kompaktanleitung`}
       </a>
     </>
   );

--- a/src/e-bikes/helper/styler.tsx
+++ b/src/e-bikes/helper/styler.tsx
@@ -68,11 +68,9 @@ export const getSymbolSVG = (
                         }
                     /* ]]> */
                     </style>
-                <svg x="${svgSize / bdim.width / 2}" y="${
-                  svgSize / bdim.height / 2
-                }"  width="${svgSize - (2 * svgSize) / bdim.width / 2}" height="${
-                  svgSize - (2 * svgSize) / bdim.height / 2
-                }" viewBox="0 0 ${bdim.width} ${bdim.height || 24}">       
+                <svg x="${svgSize / bdim.width / 2}" y="${svgSize / bdim.height / 2
+    }"  width="${svgSize - (2 * svgSize) / bdim.width / 2}" height="${svgSize - (2 * svgSize) / bdim.height / 2
+    }" viewBox="0 0 ${bdim.width} ${bdim.height || 24}">       
                     ${svgCodeInput}
                 </svg>
                 </svg>  `;
@@ -126,20 +124,19 @@ export const getFeatureStyler = (svgSize = 24) => {
     let selectionBox = canvasSize - 6;
     let badge = feature.properties.svgBadge || fallbackSVG; //|| `<image x="${(svgSize - 20) / 2}" y="${(svgSize - 20) / 2}" width="20" height="20" xlink:href="/pois/signaturen/`+getSignatur(feature.properties)+`" />`;
 
-    let svg = `<svg id="badgefor_${
-      feature.id
-    }" height="${canvasSize}" width="${canvasSize}"> 
+    let svg = `<svg id="badgefor_${feature.id
+      }" height="${canvasSize}" width="${canvasSize}"> 
                       <style>
                       /* <![CDATA[ */
                           #badgefor_${feature.id} .bg-fill  {
                               fill: ${getColorForProperties(
-                                feature.properties
-                              )};
+        feature.properties
+      )};
                           }
                           #badgefor_${feature.id} .bg-stroke  {
                               stroke: ${getColorForProperties(
-                                feature.properties
-                              )};
+        feature.properties
+      )};
                           }
                           #badgefor_${feature.id} .fg-fill  {
                               fill: white;
@@ -149,11 +146,9 @@ export const getFeatureStyler = (svgSize = 24) => {
                           }
                       /* ]]> */
                       </style>
-                  <svg x="${svgSize / 12}" y="${svgSize / 12}"  width="${
-                    svgSize - (2 * svgSize) / 12
-                  }" height="${svgSize - (2 * svgSize) / 12}" viewBox="0 0 ${
-                    feature.properties.svgBadgeDimension?.width
-                  } ${feature.properties.svgBadgeDimension?.height}">       
+                  <svg x="${svgSize / 12}" y="${svgSize / 12}"  width="${svgSize - (2 * svgSize) / 12
+      }" height="${svgSize - (2 * svgSize) / 12}" viewBox="0 0 ${feature.properties.svgBadgeDimension?.width
+      } ${feature.properties.svgBadgeDimension?.height}">       
                       ${badge}
                   </svg>
                   </svg>  `;
@@ -164,42 +159,21 @@ export const getFeatureStyler = (svgSize = 24) => {
       let badgeDimension = svgSize - (2 * svgSize) / 12;
       let innerBadgeOffset = (selectionBox - badgeDimension) / 2;
 
-      svg =
-        `<svg id="badgefor_${
-          feature.id
-        }" height="${canvasSize}" width="${canvasSize}">
-                      <style>
-                      /* <![CDATA[ */
-                          #badgefor_${feature.id} .bg-fill  {
-                              fill: ${getColorForProperties(
-                                feature.properties
-                              )};
-                          }
-                          #badgefor_${feature.id} .bg-stroke  {
-                              stroke: ${getColorForProperties(
-                                feature.properties
-                              )};
-                          }
-                          #badgefor_${feature.id} .fg-fill  {
-                              fill: white;
-                          }
-                          #badgefor_${feature.id} .fg-stroke  {
-                              stroke: white;
-                          }
-                      /* ]]> */
-                      </style>
-                  <rect x="${selectionOffset}" y="${selectionOffset}" rx="8" ry="8" width="${selectionBox}" height="${selectionBox}" fill="rgba(67, 149, 254, 0.8)" stroke-width="0"/>
-                  <svg x="${selectionOffset + innerBadgeOffset}" y="${
-                    selectionOffset + innerBadgeOffset
-                  }" width="${badgeDimension}" height="${badgeDimension}" viewBox="0 0 ` +
-        feature.properties.svgBadgeDimension?.width +
-        ` ` +
-        feature.properties.svgBadgeDimension?.height +
-        `">
-                  ${badge}
-  
-                  </svg>
-                  </svg>`;
+      svg = `
+<svg id="badgefor_${feature.id}" height="${canvasSize}" width="${canvasSize}">
+  <style>
+    /* <![CDATA[ */
+    #badgefor_${feature.id} .bg-fill {fill: ${getColorForProperties(feature.properties)};}
+    #badgefor_${feature.id} .bg-stroke {stroke: ${getColorForProperties(feature.properties)};}
+    #badgefor_${feature.id} .fg-fill {fill: white;}
+    #badgefor_${feature.id} .fg-stroke {stroke: white;}
+    /* ]]> */
+  </style>
+  <rect x="${selectionOffset}" y="${selectionOffset}" rx="8" ry="8" width="${selectionBox}" height="${selectionBox}" fill="rgba(67, 149, 254, 0.8)" stroke-width="0"/>
+  <svg x="${selectionOffset + innerBadgeOffset}" y="${selectionOffset + innerBadgeOffset}" width="${badgeDimension}" height="${badgeDimension}" viewBox="0 0 ${feature.properties.svgBadgeDimension?.width || "0"} ${feature.properties.svgBadgeDimension?.height || "0"}">
+    ${badge}
+  </svg>
+</svg>`;
     }
 
     const style = {

--- a/src/ehrenamtskarte/SectionTitleMerkliste.tsx
+++ b/src/ehrenamtskarte/SectionTitleMerkliste.tsx
@@ -1,3 +1,3 @@
 export const SectionTitleMerkliste = ({ bookmarks }) => {
-  return `meine Merkliste ${"(" + bookmarks + ")"}`;
+  return `meine Merkliste ${`(${bookmarks})`}`;
 };

--- a/src/klimaorte/ConfigurableDocBlocks.tsx
+++ b/src/klimaorte/ConfigurableDocBlocks.tsx
@@ -1,0 +1,224 @@
+import React from "react";
+import parse, { domToReact } from "html-react-parser";
+import Markdown from "react-markdown";
+//import LicenseLuftbildKarte from "./wuppertal/LicenseLuftbildkarte";
+import LicenseLuftbildKarte from "react-cismap/topicmaps/wuppertal/LicenseLuftbildkarte";
+import LicenseStadtplanTagNacht from "react-cismap/topicmaps/wuppertal/LicenseStadtplanTagNacht";
+// import { faqEntriesFactory } from "../tools/uiHelper";
+import { faqEntriesFactory } from "react-cismap/tools/uiHelper";
+import GenericHelpTextForMyLocation from "react-cismap/topicmaps/docBlocks/GenericHelpTextForMyLocation";
+import InKartePositionieren from "react-cismap/topicmaps/docBlocks/InKartePositionieren";
+import Einstellungen from "react-cismap/topicmaps/docBlocks/Einstellungen";
+import KartendarstellungDerFachobjekte from "react-cismap/topicmaps/docBlocks/KartendarstellungDerFachobjekte";
+import FachobjekteAuswaehlenUndAbfragen from "react-cismap/topicmaps/docBlocks/FachobjekteAuswaehlenUndAbfragen";
+import CustomizableComp from "react-cismap/topicmaps/docBlocks/CustomizableComp";
+
+const DOCBLOCKSTYLES = {
+  TEXT: "TEXT",
+  HTML: "HTML",
+  REACTCOMP: "REACTCOMP",
+  MARKDOWN: "MARKDOWN",
+  FAQS: "FAQS",
+  DOCBLOCK: "DOCBLOCK",
+  LICENSE_LBK: "LICENSE_LBK",
+  LICENSE_STADTPLAN: "LICENSE_STADTPLAN",
+  MEINSTANDORT: "MEINSTANDORT",
+  INKARTEPOSITIONIEREN: "INKARTEPOSITIONIEREN",
+  EINSTELLUNGEN: "EINSTELLUNGEN",
+  KARTENDARSTELLUNGDERFACHOBJEKTE: "KARTENDARSTELLUNGDERFACHOBJEKTE",
+  FACHOBJEKTEAUSWAEHLENUNDABFRAGEN: "FACHOBJEKTEAUSWAEHLENUNDABFRAGEN",
+  CUSTOMIZABLECOMP: "CUSTOMIZABLECOMP",
+};
+
+type BlockConfig = {
+  type: keyof typeof DOCBLOCKSTYLES;
+  style?: React.CSSProperties;
+  text?: string;
+};
+
+interface ConfigurableDocBlocksConfig {
+  configs: BlockConfig[];
+  style?: React.CSSProperties;
+}
+
+export const ConfigurableDocBlocks = ({
+  configs = [
+    {
+      type: "TEXT",
+      style: {
+        color: "black",
+      },
+      text: "<ConfigurableDocBlocks/> ohne Konfiguration",
+    },
+  ],
+  style,
+}: ConfigurableDocBlocksConfig) => {
+  const blocks = [];
+
+  for (const block of configs) {
+    // @ts-expect-error: TODO: fix type
+    blocks.push(getBlock4Config(block));
+  }
+
+  return /*#__PURE__*/ React.createElement(
+    "div",
+    {
+      style: style,
+    },
+    blocks
+  );
+};
+
+const getBlock4Config = (block, key) => {
+  switch (block.type) {
+    case DOCBLOCKSTYLES.TEXT:
+      //params: text, style
+      return /*#__PURE__*/ React.createElement(
+        "div",
+        {
+          key: key,
+          style: block.style,
+        },
+        block.text
+      );
+
+    case DOCBLOCKSTYLES.MARKDOWN:
+      //params: md, style
+      return /*#__PURE__*/ React.createElement(
+        "div",
+        {
+          key: key,
+          style: block.style,
+        },
+        /*#__PURE__*/ React.createElement(Markdown, {
+          escapeHtml: false,
+          source: block.content,
+        })
+      );
+
+    case DOCBLOCKSTYLES.LICENSE_LBK:
+      return /*#__PURE__*/ React.createElement(LicenseLuftbildKarte, null);
+
+    case DOCBLOCKSTYLES.LICENSE_STADTPLAN:
+      return /*#__PURE__*/ React.createElement(LicenseStadtplanTagNacht, null);
+
+    case DOCBLOCKSTYLES.MEINSTANDORT:
+      return /*#__PURE__*/ React.createElement(
+        GenericHelpTextForMyLocation,
+        null
+      );
+
+    case DOCBLOCKSTYLES.INKARTEPOSITIONIEREN:
+      return /*#__PURE__*/ React.createElement(InKartePositionieren, null);
+
+    case DOCBLOCKSTYLES.EINSTELLUNGEN:
+      return /*#__PURE__*/ React.createElement(Einstellungen, null);
+
+    case DOCBLOCKSTYLES.KARTENDARSTELLUNGDERFACHOBJEKTE:
+      return /*#__PURE__*/ React.createElement(
+        KartendarstellungDerFachobjekte,
+        null
+      );
+
+    case DOCBLOCKSTYLES.FACHOBJEKTEAUSWAEHLENUNDABFRAGEN:
+      return /*#__PURE__*/ React.createElement(
+        FachobjekteAuswaehlenUndAbfragen,
+        null
+      );
+
+    case DOCBLOCKSTYLES.DOCBLOCK:
+      //params: docBlockConfigs, style, innerStyle
+      return /*#__PURE__*/ React.createElement(
+        "div",
+        {
+          style: block.style,
+        },
+        /*#__PURE__*/ React.createElement(ConfigurableDocBlocks, {
+          style: block.innerStyle,
+          configs: block.docBlockConfigs,
+          key: key,
+        })
+      );
+
+    case DOCBLOCKSTYLES.HTML:
+      //params: docBlockConfigs, style, innerStyle
+      if (block.replaceConfig === undefined) {
+        return /*#__PURE__*/ React.createElement(
+          "div",
+          {
+            key: `DOCBLOCKSTYLES.HTML.${key}`,
+            style: block.style,
+          },
+          parse(block.content)
+        );
+      } else {
+        const options = {
+          replace: ({ attribs, children }) => {
+            if (!attribs) return;
+            const replacementInfo = block.replaceConfig[attribs.id];
+
+            if (replacementInfo !== undefined) {
+              // return tReact.createElement(LicenseLuftbildKarte, {});
+              return getBlock4Config(replacementInfo, key);
+            } else {
+              return domToReact(children, options);
+            } // if (Object.keys(block.replaceConfig).indexOf()
+            // return React.createElement(LicenseLuftbildKarte, {});
+          },
+        };
+        const x = parse(block.content, options);
+        return x;
+      }
+
+    case DOCBLOCKSTYLES.REACTCOMP:
+      //params: content
+      return block.content;
+
+    case DOCBLOCKSTYLES.CUSTOMIZABLECOMP:
+      //params: customizationKey, customizationComponent
+      return /*#__PURE__*/ React.createElement(CustomizableComp, {
+        key: block.customizationKey,
+        customizationComponent: block.customizationComponent,
+        customizationKey: block.customizationKey,
+      });
+
+    case DOCBLOCKSTYLES.FAQS: {
+      const showOnSeperatePage = false;
+      let i = 0;
+
+      for (const faqConfig of block.configs) {
+        let key = `DOCBLOCKSTYLES.FAQS.${i}`;
+
+        if (faqConfig.contentBlockConf !== undefined) {
+          faqConfig.content = getBlock4Config(faqConfig.contentBlockConf, key);
+        }
+
+        i++;
+      }
+
+      const { linkArray, entryArray } = faqEntriesFactory(
+        showOnSeperatePage,
+        block.configs
+      );
+      return /*#__PURE__*/ React.createElement(
+        "div",
+        {
+          key: `DOCVBLOCKFAQ.${key}`,
+          style: block.style,
+          name: "help",
+        },
+        /*#__PURE__*/ React.createElement(
+          "font",
+          {
+            size: "3",
+          },
+          linkArray
+        ),
+        entryArray
+      );
+    }
+
+    default:
+      break;
+  }
+};


### PR DESCRIPTION
Text einheitlich als Template Literals einbinden.

Refrenz:
- https://wiki.selfhtml.org/wiki/JavaScript/Objekte/String/template-literal
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals

Vorteile: 

* kompakter code: https://github.com/cismet-collab/carma-wuppertal-collab/commit/e6dacaf8603c043d9bea51e285b31b6a50123862#diff-af9c1a8e33a0a91267a794e9b08ea3093f60e19330c088145428e0203b784d7aL12
* einheitliches format wenn variablen benutzt werden sollten
* Zeilenumbrüche im template string möglich
* falls Text-String mit Variablen ausgetauscht werden sollen, ist kein weiteres Umschreiben nötig.
* kein HTML-Escaping von Umlauten nötig -> bessere Lesbarkeit.

Selber Output:
```
const KARTENTYP = `B-Plan`

<p>{`B-Plan`}</p> 
<p>{`${KARTENTYP}`}</p>
<p>{KARTENTYP}</p>
```

zum validieren `npm run lint` ausführen.
bzw `npx eslint src/bplan-auskunft/` mit dem zu testenden Pfad oder Datei.

Akzeptanz-Kriterien:

- [ ] Absprache mit Wuppertal
- [ ] Developer Style Guide
- [ ] Keine Seiteneneffekte im Commit

